### PR TITLE
Update Cargo.toml repository url to this one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["generation", "index", "arena", "ecs"]
 license = "MPL-2.0"
 name = "typed-generational-arena"
 readme = "./README.md"
-repository = "https://gitlab.com/tekne/typed-generational-arena"
+repository = "https://github.com/imbrem/typed-generational-arena"
 version = "0.2.9"
 edition = "2015"
 


### PR DESCRIPTION
I like this crate a lot, when looking at the sources on crates.io, the url directs you to the old gitlab sources and after some search i found it's this. I think it should be changed in case someone wants to contribute or create issues