### PR TITLE
Update dependencies, remove gen variable name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ version = "0.2.9"
 edition = "2015"
 
 [dependencies]
-cfg-if = "0.1.5"
+cfg-if = "1.0.1"
 serde = { version = "1.0", optional = true, default-features = false }
 num-traits = { version = "0.2", default-features = false }
-nonzero_ext = "0.1"
+nonzero_ext = "0.3.0"
 
 [dev-dependencies]
 quickcheck = "1.0"
-criterion = "0.5"
+criterion = "0.6.0"
 serde_test = "1.0"
-bincode = "1.0"
+bincode = "2.0.1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [[bench]]

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -2,6 +2,8 @@
 extern crate criterion;
 extern crate typed_generational_arena;
 
+use std::hint::black_box;
+
 use criterion::{BenchmarkId, Criterion, Throughput};
 use typed_generational_arena::{
     PtrSlab, PtrSlabIndex, SmallPtrSlab, SmallPtrSlabIndex, SmallSlab, SmallSlabIndex,
@@ -23,19 +25,19 @@ fn insert<T: Default>(n: usize) {
     let mut arena = Arena::<T>::new();
     for _ in 0..n {
         let idx = arena.insert(Default::default());
-        criterion::black_box(idx);
+        black_box(idx);
     }
 }
 
 fn lookup<T>(arena: &Arena<T>, idx: Index<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(&arena[idx]);
+        black_box(&arena[idx]);
     }
 }
 
 fn collect<T>(arena: &Arena<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(arena.iter().collect::<Vec<_>>());
+        black_box(arena.iter().collect::<Vec<_>>());
     }
 }
 
@@ -43,19 +45,19 @@ fn u32_insert<T: Default>(n: usize) {
     let mut arena = SmallArena::<T>::new();
     for _ in 0..n {
         let idx = arena.insert(Default::default());
-        criterion::black_box(idx);
+        black_box(idx);
     }
 }
 
 fn u32_lookup<T>(arena: &SmallArena<T>, idx: SmallIndex<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(&arena[idx]);
+        black_box(&arena[idx]);
     }
 }
 
 fn u32_collect<T>(arena: &SmallArena<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(arena.iter().collect::<Vec<_>>());
+        black_box(arena.iter().collect::<Vec<_>>());
     }
 }
 
@@ -63,19 +65,19 @@ fn slab_insert<T: Default>(n: usize) {
     let mut slab = Slab::<T>::new();
     for _ in 0..n {
         let idx = slab.insert(Default::default());
-        criterion::black_box(idx);
+        black_box(idx);
     }
 }
 
 fn slab_lookup<T>(slab: &Slab<T>, idx: SlabIndex<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(&slab[idx]);
+        black_box(&slab[idx]);
     }
 }
 
 fn slab_collect<T>(slab: &Slab<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(slab.iter().collect::<Vec<_>>());
+        black_box(slab.iter().collect::<Vec<_>>());
     }
 }
 
@@ -83,19 +85,19 @@ fn u32_slab_insert<T: Default>(n: usize) {
     let mut slab = SmallSlab::<T>::new();
     for _ in 0..n {
         let idx = slab.insert(Default::default());
-        criterion::black_box(idx);
+        black_box(idx);
     }
 }
 
 fn u32_slab_lookup<T>(slab: &SmallSlab<T>, idx: SmallSlabIndex<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(&slab[idx]);
+        black_box(&slab[idx]);
     }
 }
 
 fn u32_slab_collect<T>(slab: &SmallSlab<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(slab.iter().collect::<Vec<_>>());
+        black_box(slab.iter().collect::<Vec<_>>());
     }
 }
 
@@ -103,19 +105,19 @@ fn ptr_slab_insert<T: Default>(n: usize) {
     let mut slab = PtrSlab::<T>::new();
     for _ in 0..n {
         let idx = slab.insert(Default::default());
-        criterion::black_box(idx);
+        black_box(idx);
     }
 }
 
 fn ptr_slab_lookup<T>(slab: &PtrSlab<T>, idx: PtrSlabIndex<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(&slab[idx]);
+        black_box(&slab[idx]);
     }
 }
 
 fn ptr_slab_collect<T>(slab: &PtrSlab<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(slab.iter().collect::<Vec<_>>());
+        black_box(slab.iter().collect::<Vec<_>>());
     }
 }
 
@@ -123,19 +125,19 @@ fn u32_ptr_slab_insert<T: Default>(n: usize) {
     let mut slab = SmallPtrSlab::<T>::new();
     for _ in 0..n {
         let idx = slab.insert(Default::default());
-        criterion::black_box(idx);
+        black_box(idx);
     }
 }
 
 fn u32_ptr_slab_lookup<T>(slab: &SmallPtrSlab<T>, idx: SmallPtrSlabIndex<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(&slab[idx]);
+        black_box(&slab[idx]);
     }
 }
 
 fn u32_ptr_slab_collect<T>(slab: &SmallPtrSlab<T>, n: usize) {
     for _ in 0..n {
-        criterion::black_box(slab.iter().collect::<Vec<_>>());
+        black_box(slab.iter().collect::<Vec<_>>());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ where
     /// Attempt to construct a generation from an index
     #[inline(always)]
     pub fn from_idx(ix: T) -> Option<Self> {
-        ix.as_nonzero().map(|gen| NonzeroGeneration { gen })
+        ix.into_nonzero().map(|gen| NonzeroGeneration { gen })
     }
 }
 
@@ -235,7 +235,7 @@ where
     #[inline(always)]
     fn first_generation() -> Self {
         NonzeroGeneration {
-            gen: T::one().as_nonzero().unwrap(),
+            gen: T::one().into_nonzero().unwrap(),
         }
     }
     #[inline(always)]
@@ -256,7 +256,7 @@ where
 {
     #[inline(always)]
     fn increment_generation(&mut self) {
-        self.gen = (T::from(self.gen.get()) + T::one()).as_nonzero().unwrap()
+        self.gen = (T::from(self.gen.get()) + T::one()).into_nonzero().unwrap()
     }
 }
 
@@ -282,7 +282,7 @@ where
     #[inline(always)]
     fn first_generation() -> Self {
         NonzeroWrapGeneration {
-            gen: T::one().as_nonzero().unwrap(),
+            gen: T::one().into_nonzero().unwrap(),
         }
     }
     #[inline(always)]
@@ -308,7 +308,7 @@ where
         self.gen = if T::zero() == new {
             Self::first_generation().gen
         } else {
-            new.as_nonzero().unwrap()
+            new.into_nonzero().unwrap()
         }
     }
 }
@@ -409,7 +409,7 @@ where
     #[inline(always)]
     fn from_idx(idx: usize) -> Self {
         NonZeroIndex {
-            idx: T::from_usize(idx + 1).unwrap().as_nonzero().unwrap(),
+            idx: T::from_usize(idx + 1).unwrap().into_nonzero().unwrap(),
         }
     }
     #[inline(always)]
@@ -543,8 +543,8 @@ impl<T, I: ArenaIndex, G: FixedGenerationalIndex> Index<T, I, G> {
     #[inline]
     pub fn new(index: I, generation: G) -> Index<T, I, G> {
         Index {
-            index: index,
-            generation: generation,
+            index,
+            generation,
             _phantom: std::marker::PhantomData,
         }
     }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -1,11 +1,11 @@
-use super::{Arena, Index, NonzeroGeneration, NonzeroWrapGeneration, NonZeroIndex, DisableRemoval};
+use super::{Arena, DisableRemoval, Index, NonZeroIndex, NonzeroGeneration, NonzeroWrapGeneration};
 
 /// An arena of `T` indexed by `usize`, with `2^{64}` generations
 pub type U64Arena<T> = Arena<T, usize, u64>;
 /// An index into a `U64Arena`
 pub type U64Index<T> = Index<T, usize, u64>;
 /// A standard arena of `T` indexed by `usize`, with `2^{64} - 1` generations
-pub type StandardArena<T> =  Arena<T, usize, NonzeroGeneration<usize>>;
+pub type StandardArena<T> = Arena<T, usize, NonzeroGeneration<usize>>;
 /// A typed index into a `StandardArena`
 pub type StandardIndex<T> = Index<T, usize, NonzeroGeneration<usize>>;
 /// An arena which can only hold up to \(2^{32} - 1\) elements and generations

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,4 +1,4 @@
-use super::{Arena, GenerationalIndex, ArenaIndex, Entry, Vec, DEFAULT_CAPACITY};
+use super::{Arena, ArenaIndex, Entry, GenerationalIndex, Vec, DEFAULT_CAPACITY};
 use core::fmt;
 use core::iter;
 use core::marker::PhantomData;
@@ -9,7 +9,7 @@ impl<T, I, G> Serialize for Arena<T, I, G>
 where
     T: Serialize,
     I: ArenaIndex,
-    G: GenerationalIndex + Serialize
+    G: GenerationalIndex + Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -24,12 +24,11 @@ where
     }
 }
 
-impl<'de, T, I, G> Deserialize<'de>
-for Arena<T, I, G>
+impl<'de, T, I, G> Deserialize<'de> for Arena<T, I, G>
 where
     T: Deserialize<'de>,
     I: ArenaIndex,
-    G: GenerationalIndex + Deserialize<'de>
+    G: GenerationalIndex + Deserialize<'de>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -55,7 +54,7 @@ impl<'de, T, I, G> Visitor<'de> for ArenaVisitor<T, I, G>
 where
     T: Deserialize<'de>,
     I: ArenaIndex,
-    G: GenerationalIndex + Deserialize<'de>
+    G: GenerationalIndex + Deserialize<'de>,
 {
     type Value = Arena<T, I, G>;
 
@@ -73,10 +72,14 @@ where
         let mut generation = G::first_generation();
         while let Some(element) = access.next_element::<Option<(G, T)>>()? {
             let item = match element {
-                Some((gen, value)) => {
-                    generation = if generation.generation_lt(&gen) { gen } else { generation };
+                Some((gen_value, value)) => {
+                    generation = if generation.generation_lt(&gen_value) {
+                        gen_value
+                    } else {
+                        generation
+                    };
                     Entry::Occupied {
-                        generation: gen,
+                        generation: gen_value,
                         value,
                     }
                 }

--- a/tests/nano_arena_quickchecks.rs
+++ b/tests/nano_arena_quickchecks.rs
@@ -2,9 +2,9 @@ extern crate typed_generational_arena;
 #[macro_use]
 extern crate quickcheck;
 
-use typed_generational_arena::NanoArena as Arena;
 use std::collections::BTreeSet;
 use std::iter::FromIterator;
+use typed_generational_arena::NanoArena as Arena;
 
 quickcheck! {
     fn always_contains_inserted_elements(elems: Vec<usize>) -> bool {

--- a/tests/nano_arena_quickchecks.rs
+++ b/tests/nano_arena_quickchecks.rs
@@ -11,7 +11,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut elems = elems;
         // Avoid overflow
-        elems.truncate(std::u8::MAX as usize);
+        elems.truncate(u8::MAX as usize);
         let indices: Vec<_> = elems.into_iter().map(|e| arena.insert(e)).collect();
         indices.into_iter().all(|i| arena.contains(i))
     }
@@ -22,7 +22,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut elems = elems;
         // Avoid overflow
-        elems.truncate(std::u8::MAX as usize);
+        elems.truncate(u8::MAX as usize);
         let indices: Vec<_> = elems.into_iter().map(|e| arena.insert(e)).collect();
         for i in indices.iter().cloned() {
             arena.remove(i).unwrap();
@@ -36,7 +36,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut elems = elems;
         // Avoid overflow
-        elems.truncate(std::u8::MAX as usize);
+        elems.truncate(u8::MAX as usize);
 
         let indices: Vec<_> = elems.iter().cloned().map(|e| arena.insert(e)).collect();
         for (i, idx) in indices.iter().cloned().enumerate() {
@@ -57,7 +57,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut ops = ops;
         // Avoid overflow
-        ops.truncate(std::u8::MAX as usize);
+        ops.truncate(u8::MAX as usize);
         let mut live_indices = vec![];
         let mut dead_indices = vec![];
 
@@ -94,7 +94,7 @@ quickcheck! {
 
 quickcheck! {
     fn iter(elems: BTreeSet<usize>) -> bool {
-        let arena = Arena::from_iter(elems.iter().take(std::u8::MAX as usize).cloned());
+        let arena = Arena::from_iter(elems.iter().take(u8::MAX as usize).cloned());
         arena.iter().all(|(idx, value)| {
             elems.contains(value) && arena.get(idx) == Some(value)
         })
@@ -103,7 +103,7 @@ quickcheck! {
 
 quickcheck! {
     fn iter_mut(elems: BTreeSet<usize>) -> bool {
-        let mut arena = Arena::from_iter(elems.iter().take(std::u8::MAX as usize).cloned());
+        let mut arena = Arena::from_iter(elems.iter().take(u8::MAX as usize).cloned());
         for (_, value) in &mut arena {
             *value = value.wrapping_add(1);
         }
@@ -116,7 +116,7 @@ quickcheck! {
 
 quickcheck! {
     fn from_iter_into_iter(elems: BTreeSet<usize>) -> bool {
-        let arena = Arena::from_iter(elems.iter().take(std::u8::MAX as usize).cloned());
+        let arena = Arena::from_iter(elems.iter().take(u8::MAX as usize).cloned());
         arena.into_iter().collect::<BTreeSet<_>>() == elems
     }
 }

--- a/tests/nano_arena_tests.rs
+++ b/tests/nano_arena_tests.rs
@@ -1,6 +1,6 @@
 extern crate typed_generational_arena;
-use typed_generational_arena::NanoArena as Arena;
 use std::collections::BTreeSet;
+use typed_generational_arena::NanoArena as Arena;
 
 #[test]
 fn can_get_live_value() {

--- a/tests/nano_arena_tests.rs
+++ b/tests/nano_arena_tests.rs
@@ -39,7 +39,7 @@ fn try_insert_when_full() {
 #[test]
 fn insert_many_and_cause_doubling() {
     let mut arena = Arena::new();
-    // We can't hold more than `std::u8::MAX` items, so this was reduced from 1000 to 255.
+    // We can't hold more than `u8::MAX` items, so this was reduced from 1000 to 255.
     let indices: Vec<_> = (0..255).map(|i| arena.insert(i * i)).collect();
     for (i, idx) in indices.iter().cloned().enumerate() {
         assert_eq!(arena.remove(idx).unwrap(), i * i);
@@ -109,7 +109,7 @@ fn index_deleted_item() {
     let mut arena = Arena::new();
     let idx = arena.insert(42);
     arena.remove(idx);
-    arena[idx];
+    _ = arena[idx];
 }
 
 #[test]

--- a/tests/pointer_slab_tests.rs
+++ b/tests/pointer_slab_tests.rs
@@ -1,6 +1,6 @@
 extern crate typed_generational_arena;
-use typed_generational_arena::PtrSlab as Slab;
 use std::collections::BTreeSet;
+use typed_generational_arena::PtrSlab as Slab;
 
 #[test]
 fn can_get_live_value() {
@@ -61,7 +61,6 @@ fn into_iter() {
     assert!(set.contains(&2));
 }
 
-
 #[test]
 fn out_of_bounds_get_with_index_from_other_slab() {
     let mut slab1 = Slab::with_capacity(1);
@@ -70,7 +69,6 @@ fn out_of_bounds_get_with_index_from_other_slab() {
     let idx = slab1.insert(42);
     assert!(slab2.get(idx).is_none());
 }
-
 
 #[test]
 fn out_of_bounds_get2_mut_with_index_from_other_slab() {

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,14 +1,14 @@
 #![cfg(feature = "serde")]
 
-extern crate typed_generational_arena;
-extern crate serde;
 extern crate bincode;
+extern crate serde;
 extern crate serde_test;
+extern crate typed_generational_arena;
 
-use typed_generational_arena::{U64Arena as Arena, U64Index as Index};
 use serde::{Deserialize, Serialize};
 use serde_test::{assert_ser_tokens, Token};
 use std::fmt::Debug;
+use typed_generational_arena::{U64Arena as Arena, U64Index as Index};
 
 #[test]
 fn deserialized_arena_holds_same_values_with_original_arena() {
@@ -47,7 +47,8 @@ fn deserialized_index_can_be_used_in_the_same_way_as_original_index() {
 
     for idx in &[a, b0, b1, c, d] {
         let bytes = bincode::serialize(&idx).expect("index must be serialized");
-        let de_idx = bincode::deserialize::<Index<&'static str>>(&bytes).expect("index must be deserialized");
+        let de_idx = bincode::deserialize::<Index<&'static str>>(&bytes)
+            .expect("index must be deserialized");
         assert_eq!(arena.get(*idx), arena.get(de_idx));
     }
 }

--- a/tests/small_arena_tests.rs
+++ b/tests/small_arena_tests.rs
@@ -1,6 +1,6 @@
 extern crate typed_generational_arena;
-use typed_generational_arena::SmallArena as Arena;
 use std::collections::BTreeSet;
+use typed_generational_arena::SmallArena as Arena;
 
 #[test]
 fn can_get_live_value() {

--- a/tests/small_arena_tests.rs
+++ b/tests/small_arena_tests.rs
@@ -108,7 +108,7 @@ fn index_deleted_item() {
     let mut arena = Arena::new();
     let idx = arena.insert(42);
     arena.remove(idx);
-    arena[idx];
+    _ = arena[idx];
 }
 
 #[test]

--- a/tests/standard_arena_tests.rs
+++ b/tests/standard_arena_tests.rs
@@ -1,6 +1,6 @@
 extern crate typed_generational_arena;
-use typed_generational_arena::StandardArena as Arena;
 use std::collections::BTreeSet;
+use typed_generational_arena::StandardArena as Arena;
 
 #[test]
 fn can_get_live_value() {

--- a/tests/standard_arena_tests.rs
+++ b/tests/standard_arena_tests.rs
@@ -108,7 +108,7 @@ fn index_deleted_item() {
     let mut arena = Arena::new();
     let idx = arena.insert(42);
     arena.remove(idx);
-    arena[idx];
+    _ = arena[idx];
 }
 
 #[test]

--- a/tests/standard_slab_tests.rs
+++ b/tests/standard_slab_tests.rs
@@ -1,6 +1,6 @@
 extern crate typed_generational_arena;
-use typed_generational_arena::StandardSlab as Slab;
 use std::collections::BTreeSet;
+use typed_generational_arena::StandardSlab as Slab;
 
 #[test]
 fn can_get_live_value() {
@@ -61,7 +61,6 @@ fn into_iter() {
     assert!(set.contains(&2));
 }
 
-
 #[test]
 fn out_of_bounds_get_with_index_from_other_slab() {
     let mut slab1 = Slab::with_capacity(1);
@@ -70,7 +69,6 @@ fn out_of_bounds_get_with_index_from_other_slab() {
     let idx = slab1.insert(42);
     assert!(slab2.get(idx).is_none());
 }
-
 
 #[test]
 fn out_of_bounds_get2_mut_with_index_from_other_slab() {

--- a/tests/tiny_arena_quickchecks.rs
+++ b/tests/tiny_arena_quickchecks.rs
@@ -2,9 +2,9 @@ extern crate typed_generational_arena;
 #[macro_use]
 extern crate quickcheck;
 
-use typed_generational_arena::TinyArena as Arena;
 use std::collections::BTreeSet;
 use std::iter::FromIterator;
+use typed_generational_arena::TinyArena as Arena;
 
 quickcheck! {
     fn always_contains_inserted_elements(elems: Vec<usize>) -> bool {

--- a/tests/tiny_arena_quickchecks.rs
+++ b/tests/tiny_arena_quickchecks.rs
@@ -11,7 +11,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut elems = elems;
         // Avoid overflow
-        elems.truncate((std::u16::MAX - 1) as usize);
+        elems.truncate((u16::MAX - 1) as usize);
         let indices: Vec<_> = elems.into_iter().map(|e| arena.insert(e)).collect();
         indices.into_iter().all(|i| arena.contains(i))
     }
@@ -22,7 +22,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut elems = elems;
         // Avoid overflow
-        elems.truncate((std::u16::MAX - 1) as usize);
+        elems.truncate((u16::MAX - 1) as usize);
         let indices: Vec<_> = elems.into_iter().map(|e| arena.insert(e)).collect();
         for i in indices.iter().cloned() {
             arena.remove(i).unwrap();
@@ -36,7 +36,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut elems = elems;
         // Avoid overflow
-        elems.truncate((std::u16::MAX - 1) as usize);
+        elems.truncate((u16::MAX - 1) as usize);
 
         let indices: Vec<_> = elems.iter().cloned().map(|e| arena.insert(e)).collect();
         for (i, idx) in indices.iter().cloned().enumerate() {
@@ -57,7 +57,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut ops = ops;
         // Avoid overflow
-        ops.truncate((std::u16::MAX - 1) as usize);
+        ops.truncate((u16::MAX - 1) as usize);
         let mut live_indices = vec![];
         let mut dead_indices = vec![];
 
@@ -94,7 +94,7 @@ quickcheck! {
 
 quickcheck! {
     fn iter(elems: BTreeSet<usize>) -> bool {
-        let arena = Arena::from_iter(elems.iter().take((std::u16::MAX - 1) as usize).cloned());
+        let arena = Arena::from_iter(elems.iter().take((u16::MAX - 1) as usize).cloned());
         arena.iter().all(|(idx, value)| {
             elems.contains(value) && arena.get(idx) == Some(value)
         })
@@ -103,7 +103,7 @@ quickcheck! {
 
 quickcheck! {
     fn iter_mut(elems: BTreeSet<usize>) -> bool {
-        let mut arena = Arena::from_iter(elems.iter().take((std::u16::MAX - 1) as usize).cloned());
+        let mut arena = Arena::from_iter(elems.iter().take((u16::MAX - 1) as usize).cloned());
         for (_, value) in &mut arena {
             *value = value.wrapping_add(1);
         }
@@ -116,7 +116,7 @@ quickcheck! {
 
 quickcheck! {
     fn from_iter_into_iter(elems: BTreeSet<usize>) -> bool {
-        let arena = Arena::from_iter(elems.iter().take((std::u16::MAX - 1) as usize).cloned());
+        let arena = Arena::from_iter(elems.iter().take((u16::MAX - 1) as usize).cloned());
         arena.into_iter().collect::<BTreeSet<_>>() == elems
     }
 }

--- a/tests/tiny_arena_tests.rs
+++ b/tests/tiny_arena_tests.rs
@@ -1,6 +1,6 @@
 extern crate typed_generational_arena;
-use typed_generational_arena::TinyArena as Arena;
 use std::collections::BTreeSet;
+use typed_generational_arena::TinyArena as Arena;
 
 #[test]
 fn can_get_live_value() {

--- a/tests/tiny_arena_tests.rs
+++ b/tests/tiny_arena_tests.rs
@@ -108,7 +108,7 @@ fn index_deleted_item() {
     let mut arena = Arena::new();
     let idx = arena.insert(42);
     arena.remove(idx);
-    arena[idx];
+    _ = arena[idx];
 }
 
 #[test]

--- a/tests/tiny_wrap_arena_quickchecks.rs
+++ b/tests/tiny_wrap_arena_quickchecks.rs
@@ -11,7 +11,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut elems = elems;
         // Avoid overflow
-        elems.truncate((std::u16::MAX - 1) as usize);
+        elems.truncate((u16::MAX - 1) as usize);
         let indices: Vec<_> = elems.into_iter().map(|e| arena.insert(e)).collect();
         indices.into_iter().all(|i| arena.contains(i))
     }
@@ -22,7 +22,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut elems = elems;
         // Avoid overflow
-        elems.truncate((std::u16::MAX - 1) as usize);
+        elems.truncate((u16::MAX - 1) as usize);
         let indices: Vec<_> = elems.into_iter().map(|e| arena.insert(e)).collect();
         for i in indices.iter().cloned() {
             arena.remove(i).unwrap();
@@ -36,7 +36,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut elems = elems;
         // Avoid overflow
-        elems.truncate((std::u16::MAX - 1) as usize);
+        elems.truncate((u16::MAX - 1) as usize);
 
         let indices: Vec<_> = elems.iter().cloned().map(|e| arena.insert(e)).collect();
         for (i, idx) in indices.iter().cloned().enumerate() {
@@ -57,7 +57,7 @@ quickcheck! {
         let mut arena = Arena::new();
         let mut ops = ops;
         // Avoid overflow
-        ops.truncate((std::u16::MAX - 1) as usize);
+        ops.truncate((u16::MAX - 1) as usize);
         let mut live_indices = vec![];
         let mut dead_indices = vec![];
 
@@ -94,7 +94,7 @@ quickcheck! {
 
 quickcheck! {
     fn iter(elems: BTreeSet<usize>) -> bool {
-        let arena = Arena::from_iter(elems.iter().take((std::u16::MAX - 1) as usize).cloned());
+        let arena = Arena::from_iter(elems.iter().take((u16::MAX - 1) as usize).cloned());
         arena.iter().all(|(idx, value)| {
             elems.contains(value) && arena.get(idx) == Some(value)
         })
@@ -103,7 +103,7 @@ quickcheck! {
 
 quickcheck! {
     fn iter_mut(elems: BTreeSet<usize>) -> bool {
-        let mut arena = Arena::from_iter(elems.iter().take((std::u16::MAX - 1) as usize).cloned());
+        let mut arena = Arena::from_iter(elems.iter().take((u16::MAX - 1) as usize).cloned());
         for (_, value) in &mut arena {
             *value = value.wrapping_add(1);
         }
@@ -116,7 +116,7 @@ quickcheck! {
 
 quickcheck! {
     fn from_iter_into_iter(elems: BTreeSet<usize>) -> bool {
-        let arena = Arena::from_iter(elems.iter().take((std::u16::MAX - 1) as usize).cloned());
+        let arena = Arena::from_iter(elems.iter().take((u16::MAX - 1) as usize).cloned());
         arena.into_iter().collect::<BTreeSet<_>>() == elems
     }
 }

--- a/tests/tiny_wrap_arena_tests.rs
+++ b/tests/tiny_wrap_arena_tests.rs
@@ -1,6 +1,6 @@
 extern crate typed_generational_arena;
-use typed_generational_arena::TinyWrapArena as Arena;
 use std::collections::BTreeSet;
+use typed_generational_arena::TinyWrapArena as Arena;
 
 #[test]
 fn can_get_live_value() {

--- a/tests/tiny_wrap_arena_tests.rs
+++ b/tests/tiny_wrap_arena_tests.rs
@@ -108,7 +108,7 @@ fn index_deleted_item() {
     let mut arena = Arena::new();
     let idx = arena.insert(42);
     arena.remove(idx);
-    arena[idx];
+    _ = arena[idx];
 }
 
 #[test]


### PR DESCRIPTION
Updated some deps, also renamed a variable named "gen" as it is/will be a reserved keyword (most likely) for generators in upcoming rust versions (and RA kinda showed me it as an error although cargo check didn't)